### PR TITLE
Change WebPageTest location from London to Ireland as London is clogged

### DIFF
--- a/_profiles/bbcone.html
+++ b/_profiles/bbcone.html
@@ -3,7 +3,7 @@ name: "BBC One"
 default: false
 parameters:
   connectivity: "Cable"
-  location: "London_EC2"
+  location: "ec2-eu-west-1"
   runs: 5
   url: "https://www.bbc.co.uk/bbcone"
 budgets:

--- a/_profiles/category-highlights.html
+++ b/_profiles/category-highlights.html
@@ -3,7 +3,7 @@ name: "Category Highlights"
 default: false
 parameters:
   connectivity: "Cable"
-  location: "London_EC2"
+  location: "ec2-eu-west-1"
   runs: 5
   url: "https://www.bbc.co.uk/iplayer/categories/documentaries/highlights"
 budgets:

--- a/_profiles/episode.html
+++ b/_profiles/episode.html
@@ -3,7 +3,7 @@ name: "Episode"
 default: false
 parameters:
   connectivity: "Cable"
-  location: "London_EC2"
+  location: "ec2-eu-west-1"
   runs: 5
   url: "https://www.bbc.co.uk/iplayer/episode/p04qh1gk/face-to-face-dame-edith-sitwell"
 budgets:

--- a/_profiles/home.html
+++ b/_profiles/home.html
@@ -19,7 +19,7 @@ default: true
 #
 parameters:
   connectivity: "Cable"
-  location: "London_EC2"
+  location: "ec2-eu-west-1"
   runs: 5
   url: "https://www.bbc.co.uk/iplayer"
 

--- a/_profiles/recommendations.html
+++ b/_profiles/recommendations.html
@@ -3,7 +3,7 @@ name: "Recommendations (Signed Out)"
 default: false
 parameters:
   connectivity: "Cable"
-  location: "London_EC2"
+  location: "ec2-eu-west-1"
   runs: 5
   url: "https://www.bbc.co.uk/iplayer/recommendations"
 budgets:


### PR DESCRIPTION
SpeedTracker Bot hasn't committed any tests results since 28 May.

I believe this is because the WebPageTest's London location is clogged up with, at time of writing, 2595 tests in the queue (see https://www.webpagetest.org/getLocations.php?f=html&k=A)

This changes the configs to use the Ireland location instead (the next nearest one).